### PR TITLE
Fixed SynchronizationContext usage

### DIFF
--- a/Miner.App.UI.ETO.Linux/Program.cs
+++ b/Miner.App.UI.ETO.Linux/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using Eto;
 using Eto.Forms;
 
@@ -10,7 +11,9 @@ namespace HardlyMiningUI.Desktop
     public static void Main(string[] args)
     {
       // https://github.com/picoe/Eto/wiki/Running-your-application
-      new Application(Platform.Detect).Run(new MainForm());
+      var app = new Application(new Eto.GtkSharp.Platform());
+      SynchronizationContext.SetSynchronizationContext(new UISynchronizationContext(app));
+      app.Run(new MainForm());
     }
   }
 }

--- a/Miner.App.UI.ETO.Mac/Program.cs
+++ b/Miner.App.UI.ETO.Mac/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using Eto;
 using Eto.Forms;
 
@@ -10,7 +11,9 @@ namespace HardlyMiningUI.Desktop
     public static void Main(string[] args)
     {
       // https://github.com/picoe/Eto/wiki/Running-your-application
-      new Application(Platform.Detect).Run(new MainForm());
+      var app = new Application(Platform.Detect);
+      SynchronizationContext.SetSynchronizationContext(new UISynchronizationContext(app));
+      app.Run(new MainForm());
     }
   }
 }

--- a/Miner.App.UI.ETO.Windows/Program.cs
+++ b/Miner.App.UI.ETO.Windows/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using Eto;
 using Eto.Forms;
 
@@ -10,7 +11,9 @@ namespace HardlyMiningUI.Desktop
     public static void Main(string[] args)
     {
       // https://github.com/picoe/Eto/wiki/Running-your-application
-      new Application(Platform.Detect).Run(new MainForm());
+      var app = new Application(Platform.Detect);
+      SynchronizationContext.SetSynchronizationContext(new UISynchronizationContext(app));
+      app.Run(new MainForm());
     }
   }
 }

--- a/Miner.App.UI.ETO/Miner.App.UI.ETO.csproj
+++ b/Miner.App.UI.ETO/Miner.App.UI.ETO.csproj
@@ -45,6 +45,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="UISynchronizationContext.cs" />
     <EmbeddedResource Include="MainForm.xeto">
       <SubType>Designer</SubType>
     </EmbeddedResource>

--- a/Miner.App.UI.ETO/UISynchronizationContext.cs
+++ b/Miner.App.UI.ETO/UISynchronizationContext.cs
@@ -1,0 +1,25 @@
+﻿using System.Threading;
+using Eto.Forms;
+
+namespace HardlyMiningUI
+{
+  public class UISynchronizationContext : SynchronizationContext
+  {
+    private readonly Application application;
+
+    public UISynchronizationContext(Application app)
+    {
+        application = app;
+    }
+
+    public override void Send(SendOrPostCallback d, object state)
+    {
+        application.Invoke(() => d(state));
+    }
+
+    public override void Post(SendOrPostCallback d, object state)
+    {
+        application.AsyncInvoke(() => d(state));
+    }
+  }
+}

--- a/Miner.App/Data/ViewModels/ViewModel.cs
+++ b/Miner.App/Data/ViewModels/ViewModel.cs
@@ -13,7 +13,7 @@ namespace HD
 
     public ViewModel()
     {
-      context = new SynchronizationContext();
+      context = SynchronizationContext.Current;
     }
 
     protected void OnPropertyChanged([CallerMemberName] string propertyName = null) //[CallerMemberName] allows you to call this method without having to send the name. less typing. 


### PR DESCRIPTION
The default SynchronizationContext implementation for Send invokes the callback on the calling thread and Post invokes the callback on the .net ThreadPool

and it doesn't look like eto sets a custom SynchronizationContext implementation on the UI thread so we have to do it